### PR TITLE
Refactor flex container

### DIFF
--- a/core/crates/layout/src/tree.rs
+++ b/core/crates/layout/src/tree.rs
@@ -1,7 +1,7 @@
 use super::Material;
 use math::{Rect, Vector2};
 use std::collections::VecDeque;
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 
 /// This is the essential trait of the box model. It is implemented by all
 /// components that undergo the box layout process.

--- a/core/crates/layout/tests/canary_layouts.rs
+++ b/core/crates/layout/tests/canary_layouts.rs
@@ -1,0 +1,113 @@
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::similar_names)]
+
+use layout::{
+    Axis, BoxConstraints, Color, Container, CrossAxisAlignment, EdgeInsets, Flex, Flexible, Layout,
+    LayoutBox, LayoutTree, MainAxisAlignment, MainAxisSize, Material,
+};
+use math::{Rect, Vector2};
+use test_util::assert_slice_eq;
+
+#[test]
+pub fn canary_layouts_flex_sidebar() {
+    let widgets = Flex {
+        axis: Axis::Horizontal,
+        main_axis_size: MainAxisSize::Max,
+        main_axis_alignment: MainAxisAlignment::Start,
+        cross_axis_alignment: CrossAxisAlignment::Stretch,
+        children: vec![
+            Box::new(Container {
+                size: (50.0, f32::INFINITY).into(),
+                color: Color::green(),
+                padding: EdgeInsets::all(10.0),
+                child: Some(Box::new(Flex {
+                    axis: Axis::Vertical,
+                    main_axis_size: MainAxisSize::Max,
+                    main_axis_alignment: MainAxisAlignment::Start,
+                    cross_axis_alignment: CrossAxisAlignment::Stretch,
+                    children: vec![
+                        Box::new(Container {
+                            size: (f32::INFINITY, 25.0).into(),
+                            margin: EdgeInsets::bottom(15.0),
+                            color: Color::red(),
+                            ..Container::default()
+                        }),
+                        Box::new(Container {
+                            size: (f32::INFINITY, 25.0).into(),
+                            margin: EdgeInsets::bottom(15.0),
+                            color: Color::red(),
+                            ..Container::default()
+                        }),
+                    ],
+                })),
+                ..Container::default()
+            }),
+            Box::new(Flexible {
+                flex_factor: 1.0,
+                child: Box::new(Container {
+                    color: Color::blue(),
+                    ..Container::default()
+                }),
+            }),
+        ],
+    };
+
+    let constraints = BoxConstraints::from_max(Vector2::new(100.0, 100.0));
+    let actual_layout = layout_with_constraints(&widgets, &constraints);
+    let expected_layout = vec![
+        LayoutBox {
+            rect: Rect::from_pos((0.0, 0.0), (30.0, 25.0)),
+            children: vec![],
+            material: Material::Solid(Color::red()),
+        },
+        LayoutBox {
+            rect: Rect::from_pos((0.0, 0.0), (30.0, 25.0)),
+            children: vec![],
+            material: Material::Solid(Color::red()),
+        },
+        LayoutBox {
+            rect: Rect::from_pos((0.0, 0.0), (30.0, 40.0)),
+            children: vec![0],
+            material: Material::None,
+        },
+        LayoutBox {
+            rect: Rect::from_pos((0.0, 40.0), (30.0, 40.0)),
+            children: vec![1],
+            material: Material::None,
+        },
+        LayoutBox {
+            rect: Rect::from_pos((10.0, 10.0), (30.0, 80.0)),
+            children: vec![2, 3],
+            material: Material::None,
+        },
+        LayoutBox {
+            rect: Rect::from_pos((0.0, 0.0), (50.0, 100.0)),
+            children: vec![],
+            material: Material::Solid(Color::blue()),
+        },
+        LayoutBox {
+            rect: Rect::from_pos((0.0, 0.0), (50.0, 100.0)),
+            children: vec![4],
+            material: Material::Solid(Color::green()),
+        },
+        LayoutBox {
+            rect: Rect::from_pos((50.0, 0.0), (50.0, 100.0)),
+            children: vec![5],
+            material: Material::None,
+        },
+        LayoutBox {
+            rect: Rect::from_pos((0.0, 0.0), (100.0, 100.0)),
+            children: vec![6, 7],
+            material: Material::None,
+        },
+    ];
+    assert_slice_eq(&expected_layout, &actual_layout);
+}
+
+fn layout_with_constraints(widget: &dyn Layout, constraints: &BoxConstraints) -> Vec<LayoutBox> {
+    let mut tree = LayoutTree::new();
+    let sbox = widget.layout(&mut tree, constraints);
+    let lbox = LayoutBox::from_child(sbox, (0.0, 0.0));
+    tree.insert(lbox);
+    tree.boxes
+}

--- a/core/crates/test_util/src/lib.rs
+++ b/core/crates/test_util/src/lib.rs
@@ -14,7 +14,7 @@ pub fn assert_slice_eq<T: PartialEq + Debug>(expected: &[T], actual: &[T]) {
         let actual = &actual[i];
         assert!(
             *expected == *actual,
-            "\nVectors do not match. Unexpected item at index {}.\nExpected {:?}\nActual: {:?}",
+            "\nVectors do not match. Unexpected item at index {}.\nExpected: {:?}\nActual:   {:?}",
             i,
             expected,
             actual,

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -1,5 +1,5 @@
 use layout::{
-    Axis, Center, Color, Container, CrossAxisAlignment, EdgeInsets, Flex, FlexGroup, Layout,
+    Axis, Center, Color, Container, CrossAxisAlignment, EdgeInsets, Flex, Flexible, Layout,
     MainAxisAlignment, MainAxisSize, Positioned, Stack,
 };
 use math::Vector2;
@@ -10,7 +10,7 @@ pub struct App {
 }
 
 impl AppDriver for App {
-    fn tick(&mut self, time: f32) -> Box<dyn Layout> {
+    fn tick(&mut self, _: f32) -> Box<dyn Layout> {
         self.sidebar()
     }
 }
@@ -22,142 +22,48 @@ impl App {
     }
 
     pub fn sidebar(&self) -> Box<dyn Layout> {
-        let widgets = FlexGroup {
+        let widgets = Flex {
             axis: Axis::Horizontal,
             main_axis_size: MainAxisSize::Max,
             main_axis_alignment: MainAxisAlignment::Start,
             cross_axis_alignment: CrossAxisAlignment::Stretch,
             children: vec![
-                Flex::Fixed {
-                    child: Box::new(Container {
-                        size: (200.0, f32::INFINITY).into(),
-                        color: Color::black().alpha(0.25),
-                        padding: EdgeInsets::all(10.0),
-                        child: Some(Box::new(FlexGroup {
-                            axis: Axis::Vertical,
-                            main_axis_size: MainAxisSize::Max,
-                            main_axis_alignment: MainAxisAlignment::Start,
-                            cross_axis_alignment: CrossAxisAlignment::Stretch,
-                            children: vec![
-                                Flex::Fixed {
-                                    child: Box::new(Container {
-                                        size: (f32::INFINITY, 25.0).into(),
-                                        margin: EdgeInsets::bottom(15.0),
-                                        color: Color::red(),
-                                        ..Default::default()
-                                    }),
-                                },
-                                Flex::Fixed {
-                                    child: Box::new(Container {
-                                        size: (f32::INFINITY, 25.0).into(),
-                                        margin: EdgeInsets::bottom(15.0),
-                                        color: Color::red(),
-                                        ..Default::default()
-                                    }),
-                                },
-                            ],
-                        })),
-                        ..Default::default()
-                    }),
-                },
-                Flex::Flexible {
-                    flex: 1.0,
-                    child: Box::new(Container {
-                        color: Color::blue().alpha(0.05),
-                        ..Default::default()
-                    }),
-                },
-            ],
-        };
-        Box::new(widgets)
-    }
-
-    pub fn test(&self) -> Box<dyn Layout> {
-        use layout::{Axis, FlexGroup};
-        Box::new(FlexGroup {
-            axis: Axis::Horizontal,
-            main_axis_size: MainAxisSize::Max,
-            main_axis_alignment: MainAxisAlignment::Start,
-            cross_axis_alignment: CrossAxisAlignment::Start,
-            children: vec![Flex::Flexible {
-                flex: 1.0,
-                child: Box::new(layout::Container {
-                    // A Container with a fixed, non-infinity size along the
-                    // main axis of a Flex::Flesible
-                    size: (200.0, f32::INFINITY).into(),
-                    color: Color::black().alpha(0.25),
+                Box::new(Container {
+                    size: (50.0, f32::INFINITY).into(),
+                    color: Color::green(),
                     padding: EdgeInsets::all(10.0),
-                    child: Some(Box::new(FlexGroup {
+                    child: Some(Box::new(Flex {
                         axis: Axis::Vertical,
                         main_axis_size: MainAxisSize::Max,
                         main_axis_alignment: MainAxisAlignment::Start,
                         cross_axis_alignment: CrossAxisAlignment::Stretch,
                         children: vec![
-                            Flex::Fixed {
-                                child: Box::new(layout::Container {
-                                    size: (f32::INFINITY, 25.0).into(),
-                                    margin: EdgeInsets::bottom(10.0),
-                                    color: Color::red(),
-                                    ..Default::default()
-                                }),
-                            },
-                            Flex::Fixed {
-                                child: Box::new(layout::Container {
-                                    size: (f32::INFINITY, 25.0).into(),
-                                    margin: EdgeInsets::bottom(10.0),
-                                    color: Color::red(),
-                                    ..Default::default()
-                                }),
-                            },
+                            Box::new(Container {
+                                size: (f32::INFINITY, 25.0).into(),
+                                margin: EdgeInsets::bottom(15.0),
+                                color: Color::red(),
+                                ..Default::default()
+                            }),
+                            Box::new(Container {
+                                size: (f32::INFINITY, 25.0).into(),
+                                margin: EdgeInsets::bottom(15.0),
+                                color: Color::red(),
+                                ..Default::default()
+                            }),
                         ],
                     })),
                     ..Default::default()
                 }),
-            }],
-        })
-    }
-
-    #[allow(dead_code)]
-    pub fn render_flex_group(&self) -> Box<dyn Layout> {
-        use layout::{Axis, FlexGroup};
-        Box::new(Container {
-            size: (f32::INFINITY, f32::INFINITY).into(),
-            color: Color::yellow(),
-            padding: EdgeInsets::all(10.0),
-            child: Some(Box::new(FlexGroup {
-                axis: Axis::Vertical, // Is this a bug? Or just overflow? How can we calculate when overlfow happens?
-                main_axis_size: MainAxisSize::Min,
-                main_axis_alignment: MainAxisAlignment::Start,
-                cross_axis_alignment: CrossAxisAlignment::Start,
-                children: vec![
-                    Flex::Fixed {
-                        child: Box::new(FlexGroup {
-                            axis: Axis::Horizontal,
-                            main_axis_size: MainAxisSize::Min,
-                            main_axis_alignment: MainAxisAlignment::SpaceEvenly,
-                            cross_axis_alignment: CrossAxisAlignment::Start,
-                            children: vec![Flex::Fixed {
-                                child: Box::new(Container {
-                                    margin: EdgeInsets::bottom(10.0),
-                                    size: (15.0, 25.0).into(),
-                                    color: Color::red(),
-                                    ..Default::default()
-                                }),
-                            }],
-                            ..Default::default()
-                        }),
-                    },
-                    Flex::Fixed {
-                        child: Box::new(Container {
-                            size: (200.0, 300.0).into(),
-                            color: Color::green(),
-                            ..Default::default()
-                        }),
-                    },
-                ],
-            })),
-            ..Default::default()
-        })
+                Box::new(Flexible {
+                    flex_factor: 1.0,
+                    child: Box::new(Container {
+                        color: Color::blue(),
+                        ..Default::default()
+                    }),
+                }),
+            ],
+        };
+        Box::new(widgets)
     }
 
     // The green box should be positioned at (200, 200). If not, then we are not


### PR DESCRIPTION
This PR simplifies the API for the flex container and introduces "canary layout" integration tests. It also adds a bunch of rustdoc comments.

**Simplified flex container API**

Before this PR, flex layout was done inside a `FlexGroup` which required that each child was wrapped in a `Flex::Flexible` or `Flex::Fixed` enum instance:

```rust
let widgets = FlexGroup {
    children: vec![
        Flex::Fixed {
            child: Box::new(/* fixed child */),
        },
        Flex::Flexible {
            flex: 1.0,
            child: Box::new(/* flexible child */),
        },
    ],
    ..Default::default()
};
```

This PR removes the `Flex` num requirement, and renames `FlexGroup` to `Flex`. We now only need to wrap flexible children with a `Flexible` widget:

```rust
let widgets = Flex {
    children: vec![
        Box::new(/* fixed child */),
        Flexible {
            flex: 1.0,
            child: Box::new(/* flexible child */),
        },
    ],
    ..Default::default()
};
```

Which is much nicer to use.

This is achieved by making the `Flex` struct accept `Box<dyn FlexLayout>` children instead of `Box<dyn Layout>`:

```rust
pub trait FlexLayout: Debug {
    fn flex_factor(&self) -> Option<f32>;
    fn flex_layout(&self, tree: &mut LayoutTree, constraints: &BoxConstraints) -> SizedLayoutBox;
}

pub struct Flex {
    /* snip */
    pub children: Vec<Box<dyn FlexLayout>>,
}
```

And implements `FlexLayout` as a metatrait on all existing `Layout` types:

```rust
impl<T> FlexLayout for T
where
    T: Layout,
{
    fn flex_factor(&self) -> Option<f32> {
        None
    }

    fn flex_layout(&self, tree: &mut LayoutTree, constraints: &BoxConstraints) -> SizedLayoutBox {
        self.layout(tree, constraints)
    }
}
```

Rust traits to the rescue!

**Canary layout integration tests**

Although the flex module already has an obscene number of tests, they are unit tests that target very specific and very *small* units of layout logic. They don't how different widgets might interact with each other.

The integration tests live in the `tests/` folder alongside `src/` and are for testing the composition of widgets in complex layouts.